### PR TITLE
Change permission for /claimsell command.

### DIFF
--- a/src/main/java/me/ryanhamshire/griefprevention/GriefPreventionPlugin.java
+++ b/src/main/java/me/ryanhamshire/griefprevention/GriefPreventionPlugin.java
@@ -1094,7 +1094,7 @@ public class GriefPreventionPlugin {
 
         Sponge.getCommandManager().register(this, CommandSpec.builder()
                 .description(Text.of("Puts your claim up for sale. Use /claimsell amount. Requires an economy plugin"))
-                .permission(GPPermissions.COMMAND_SELL_CLAIM_BLOCKS)
+                .permission(GPPermissions.COMMAND_CLAIM_SELL)
                 .arguments(GenericArguments.firstParsing(doubleNum(Text.of("price")), string(Text.of("cancel"))))
                 .executor(new CommandClaimSell())
                 .build(), "claimsell");


### PR DESCRIPTION
Currently it's the same permission for /claimsell as it is for /sellclaimblocks. They are different commands, different usage, why use the same permission?